### PR TITLE
S 001

### DIFF
--- a/Pasitea/Model/TopBarIconSet.swift
+++ b/Pasitea/Model/TopBarIconSet.swift
@@ -14,6 +14,5 @@ struct TopBarIconSet: OptionSet {
     static let info  = TopBarIconSet(rawValue: 1 << 1)
     static let add   = TopBarIconSet(rawValue: 1 << 2)
 
-    static let both: TopBarIconSet = [.close, .info]
     static let none: TopBarIconSet = []
 }

--- a/Pasitea/Model/TopBarIconSet.swift
+++ b/Pasitea/Model/TopBarIconSet.swift
@@ -11,7 +11,8 @@ struct TopBarIconSet: OptionSet {
     let rawValue: Int
 
     static let close = TopBarIconSet(rawValue: 1 << 0)
-    static let info = TopBarIconSet(rawValue: 1 << 1)
+    static let info  = TopBarIconSet(rawValue: 1 << 1)
+    static let add   = TopBarIconSet(rawValue: 1 << 2)
 
     static let both: TopBarIconSet = [.close, .info]
     static let none: TopBarIconSet = []

--- a/Pasitea/View/Calm/Calm - 5 Steps/CalmStepsView.swift
+++ b/Pasitea/View/Calm/Calm - 5 Steps/CalmStepsView.swift
@@ -57,7 +57,7 @@ struct CalmStepsView: View {
                     dismissAction: dismiss,
                     customDismiss: customDismiss,
                     enforce: false,
-                    display: !lastStep ? .both : .info
+                    display: !lastStep ? [.info,.close] : .info
                 ) {
                     VStack(alignment: .leading, spacing: 24) {
                         Text("5-steps")

--- a/Pasitea/View/Calm/Calm - Breathe/CalmBreatheView.swift
+++ b/Pasitea/View/Calm/Calm - Breathe/CalmBreatheView.swift
@@ -29,7 +29,7 @@ struct CalmBreatheView: View {
                 CustomBackButton(
                     dismissAction: dismiss,
                     enforce: false,
-                    display: .both
+                    display: [.info, .close]
                 ) {
                     VStack(alignment: .leading, spacing: 24) {
                         Text("Breathe")

--- a/Pasitea/View/Calm/Calm - Listen/CalmListenView.swift
+++ b/Pasitea/View/Calm/Calm - Listen/CalmListenView.swift
@@ -200,7 +200,7 @@ struct CalmListenView: View {
                     dismissAction: dismiss,
                     customAction: closeAction,
                     enforce: false,
-                    display: .both
+                    display: [.info, .close]
                 ) {
                     VStack(alignment: .leading, spacing: 24) {
                         Text("Listen")

--- a/Pasitea/View/Calm/CalmScreen.swift
+++ b/Pasitea/View/Calm/CalmScreen.swift
@@ -95,7 +95,7 @@ struct CalmScreen: View {
                 }
 
                 VStack {
-                    CustomBackButton(display: .info) {
+                    CustomBackButton(display: [.info, .add]) {
                         VStack(alignment: .leading, spacing: 24) {
                             Text("Calm")
                                 .font(.title2)

--- a/Pasitea/View/Utils/Components/CustomBackButton.swift
+++ b/Pasitea/View/Utils/Components/CustomBackButton.swift
@@ -44,13 +44,11 @@ struct CustomBackButton<Content: View>: View {
                 .sheet(isPresented: $infoPresented) {
                     content
                 }
-                if display == [.info]{ // prevents positioning of info icon at center
-                    Spacer()
-                }
             }
             
+            Spacer()
+            
             if display.contains(.close) {
-                Spacer()
                 Button(role: .none) {
                     isButtonPressed.toggle()
                     if enforce {
@@ -69,8 +67,7 @@ struct CustomBackButton<Content: View>: View {
                 }
             }
             
-            if display.contains(.add) {
-                Spacer()
+            else if display.contains(.add) {
                 Button {
                     isButtonPressed.toggle()
                     addViewIsPresented = true

--- a/Pasitea/View/Utils/Components/CustomBackButton.swift
+++ b/Pasitea/View/Utils/Components/CustomBackButton.swift
@@ -44,6 +44,9 @@ struct CustomBackButton<Content: View>: View {
                 .sheet(isPresented: $infoPresented) {
                     content
                 }
+                if display == [.info]{ // prevents positioning of info icon at center
+                    Spacer()
+                }
             }
             
             if display.contains(.close) {

--- a/Pasitea/View/Utils/Components/CustomBackButton.swift
+++ b/Pasitea/View/Utils/Components/CustomBackButton.swift
@@ -10,9 +10,10 @@ import SwiftUI
 struct CustomBackButton<Content: View>: View {
     @Environment(\.modelContext) var modelContext
 
-    @State private var infoPresented = false
-    @State private var alertPresented = false
-    @State private var isButtonPressed = false
+    @State private var infoPresented        = false
+    @State private var addViewIsPresented   = false
+    @State private var alertPresented       = false
+    @State private var isButtonPressed      = false
 
     var trackItem: TrackItem?
 
@@ -27,52 +28,56 @@ struct CustomBackButton<Content: View>: View {
 
     var body: some View {
         HStack {
-            if display.isSubset(of: .both) {
-                if display.contains(.info) {
-                    Button {
-                        isButtonPressed.toggle()
-                        infoPresented = true
-                    } label: {
-                        Label("Informations", systemImage: "info.circle")
-                            .customSingleBackButton()
-                    }
-                    .sheet(isPresented: $infoPresented) {
-                        content
-                    }
-                }
-                Spacer()
-                if display.contains(.close) {
-                    Button(role: .none) {
-                        isButtonPressed.toggle()
-                        if enforce {
-                            alertPresented = true
-                        } else {
-                            trackItem?.saveInto(modelContext)
-                            withAnimation {
-                                dismissAction?()
-                                customAction?()
-                                customDismiss?()
-                            }
-                        }
-                    } label: {
-                        Label("Close", systemImage: "xmark.circle.fill")
-                            .customSingleBackButton()
-                    }
-                }
-            } else if display.contains(.add) {
+            if display.isDisjoint(with: [.info,.close,.add]){
+                EmptyView()
+                    .frame(height: 48)
+            }
+            
+            if display.contains(.info) {
                 Button {
                     isButtonPressed.toggle()
                     infoPresented = true
                 } label: {
-                    Label("Add", systemImage: "plus.circle")
+                    Label("Informations", systemImage: "info.circle")
                         .customSingleBackButton()
                 }
                 .sheet(isPresented: $infoPresented) {
                     content
                 }
-            } else {
-                EmptyView()
-                    .frame(height: 48)
+            }
+            
+            if display.contains(.close) {
+                Spacer()
+                Button(role: .none) {
+                    isButtonPressed.toggle()
+                    if enforce {
+                        alertPresented = true
+                    } else {
+                        trackItem?.saveInto(modelContext)
+                        withAnimation {
+                            dismissAction?()
+                            customAction?()
+                            customDismiss?()
+                        }
+                    }
+                } label: {
+                    Label("Close", systemImage: "xmark.circle.fill")
+                        .customSingleBackButton()
+                }
+            }
+            
+            if display.contains(.add) {
+                Spacer()
+                Button {
+                    isButtonPressed.toggle()
+                    addViewIsPresented = true
+                } label: {
+                    Label("Add", systemImage: "plus")
+                        .customSingleBackButton()
+                }
+                .sheet(isPresented: $addViewIsPresented) {
+                    TrackItemAddView()
+                }
             }
         }
         .customHaptic(isButtonPressed)

--- a/Pasitea/View/Utils/Components/CustomBackButton.swift
+++ b/Pasitea/View/Utils/Components/CustomBackButton.swift
@@ -59,6 +59,17 @@ struct CustomBackButton<Content: View>: View {
                             .customSingleBackButton()
                     }
                 }
+            } else if display.contains(.add) {
+                Button {
+                    isButtonPressed.toggle()
+                    infoPresented = true
+                } label: {
+                    Label("Add", systemImage: "plus.circle")
+                        .customSingleBackButton()
+                }
+                .sheet(isPresented: $infoPresented) {
+                    content
+                }
             } else {
                 EmptyView()
                     .frame(height: 48)


### PR DESCRIPTION
Changed implementation of CustomBackButton in order to implement a + button.

Main changes:
- added "add" option as TopBarIconSet value
- pressing the + button opens a TrackItemAddView
- removed "both" option as it became ambiguous

Instead of old ```display: .both``` now the syntax is ```display: [.info, .close]```. 
The order of the option in the list is not relevant, in each case the "info" icon is on the left and "close" is on the right of the view.

The add button is also on the right when there is no "close" icon.

<img width="367" alt="Screenshot 2023-11-06 at 21 26 25" src="https://github.com/Pasitea/Pasitea/assets/81196565/88e4fc7c-1546-429b-a8de-45847cd6e44b">

<img width="391" alt="Screenshot 2023-11-06 at 21 29 29" src="https://github.com/Pasitea/Pasitea/assets/81196565/f13fa9fe-961b-466f-9e93-9d616f37fc56">


Now a possible display sequence could have been ```display: [.info, .add, .close]```, in this case the close button is at the center of the view.

<img width="409" alt="Screenshot 2023-11-06 at 21 30 12" src="https://github.com/Pasitea/Pasitea/assets/81196565/9ddb5659-6e76-48bf-a106-01d829f37960">

I preferred to not let this happen since it would have been ambiguous, so the "close" option will override the "add" option.
The code ```display: [.info, .add, .close]``` will have the same output as ```display: [.info, .close]``` and ```display: [.add, .close]``` will be the same of ```display: [.close]```


<img width="406" alt="Screenshot 2023-11-06 at 21 54 50" src="https://github.com/Pasitea/Pasitea/assets/81196565/69bd3cf4-c631-45af-b7b7-2483e25ed50d">
<img width="414" alt="Screenshot 2023-11-06 at 21 55 05" src="https://github.com/Pasitea/Pasitea/assets/81196565/046566cf-f022-402d-8bac-95fe3d1a4d31">


